### PR TITLE
Remove node_modules from socket and auth .dockerignore

### DIFF
--- a/services/auth/.dockerignore
+++ b/services/auth/.dockerignore
@@ -1,3 +1,2 @@
-node_modules
 package-lock.json
 **/.DS_Store

--- a/services/socket/.dockerignore
+++ b/services/socket/.dockerignore
@@ -1,3 +1,2 @@
-node_modules
 package-lock.json
 **/.DS_Store


### PR DESCRIPTION
When spinning up the docker setup, I got errors from the `socket` and `auth` containers:
```
root@instapy:~/instapy-gui# docker-compose logs auth
Attaching to instapygui_auth_1
auth_1     | 
auth_1     | > instapy-auth@1.0.0 dev /usr/instapy
auth_1     | > nodemon index.js
auth_1     | 
auth_1     | sh: nodemon: not found
auth_1     | npm ERR! code ELIFECYCLE
auth_1     | npm ERR! syscall spawn
auth_1     | npm ERR! file sh
auth_1     | npm ERR! errno ENOENT
auth_1     | npm ERR! instapy-auth@1.0.0 dev: `nodemon index.js`
auth_1     | npm ERR! spawn ENOENT
auth_1     | npm ERR! 
auth_1     | npm ERR! Failed at the instapy-auth@1.0.0 dev script.
auth_1     | npm ERR! This is probably not a problem with npm. There is likely additional logging output above.
auth_1     | npm WARN Local package.json exists, but node_modules missing, did you mean to install?
auth_1     | 
auth_1     | npm ERR! A complete log of this run can be found in:
auth_1     | npm ERR!     /root/.npm/_logs/2020-07-06T08_27_14_426Z-debug.log
```

The problem here is, that the `node_modules` directory is not persisted in the image after building it, because the directory is listed in the `.dockerignore` file.
This PR fixes the execution of `nodemon` inside the containers.

I bet there was a reason, why `node_modules` was added to the `.dockerignore` files, so please let me know if the issue is caused by something else.