### PR TITLE
Feature/add random range

### DIFF
--- a/services/config/auth.py
+++ b/services/config/auth.py
@@ -1,4 +1,5 @@
 import jwt
+import sys
 import json
 from functools import wraps
 from flask import request, current_app
@@ -20,7 +21,7 @@ def jwt_req(f):
     def decorated_function(*args, **kwargs):
         token = request.headers.get('Authorization', None)
         if not token:
-            print('error: no token provided')
+            print('error: no token provided', file=sys.stderr)
             return to_json({'error': 'no token provided', 'type': 'auth'}, 400)
 
         payload = None
@@ -29,15 +30,15 @@ def jwt_req(f):
             token = token.split(' ')[1]
             payload = jwt.decode(token, SECRET, algorithms=['HS256'])
         except:
-            print('error: decoding token')
+            print('error: decoding token', file=sys.stderr)
             return to_json({'error': 'decoding token', 'type': 'auth'}, 400)
 
         if not payload:
-            print('error: no payload')
+            print('error: no payload', file=sys.stderr)
             return to_json({'error': 'no payload', 'type': 'auth'}, 400)
 
         if not payload['username']:
-            print('error: no username')
+            print('error: no username', file=sys.stderr)
             return to_json({'error': 'no username in payload', 'type': 'auth'}, 400)
 
         return f(*args, payload=payload, **kwargs)

--- a/services/config/settings.py
+++ b/services/config/settings.py
@@ -1,4 +1,5 @@
 from os import getenv
+import sys
 from flask import Blueprint, request
 from database import client
 from auth import to_json, jwt_req, encode, decode
@@ -16,7 +17,7 @@ def coding_wrapper(text, func):
     try:
         return func(text, CIPHER_SECRET)
     except Exception as e:
-        print('error in coding wrapper', e)
+        print('error in coding wrapper', e, file=sys.stderr)
         return None
 
 
@@ -94,7 +95,7 @@ def update_settings(payload):
                 continue
 
             param['value'] = coding_wrapper(param['value'], encode)
-
+            
         table.find_one_and_update(
             {'ident': setting['ident'], 'username': username},
             {'$set': {'params': setting['params']}},

--- a/services/instapy/bot.py
+++ b/services/instapy/bot.py
@@ -1,6 +1,7 @@
 import os
 import sys
 import logging
+import random
 import requests
 import json
 import platform
@@ -97,6 +98,13 @@ for job in jobs:
             if act_param['name'] == param['name']
         )
 
+        if act_param['type'] == 'int' and type(param['value']) is dict:
+            if param['value']['is_range']:
+                param['value'] = random.randint(param['value']['min'], param['value']['max'])
+            else:
+                param['value'] = param['value']['single']
+            continue
+
         if not isinstance(param['value'], str):
             continue
 
@@ -112,7 +120,15 @@ setting = get(f'/settings/{setting_ident}')
 # user args
 instapy_args = dict()
 for param in setting['params']:
-    instapy_args[param['name']] = param['value']
+    if param['name'] == 'page_delay' or param['name'] == 'proxy_port':
+        if type(param['value']) == int: # backward compitability
+            instapy_args[param['name']] = param['value']
+        elif param['value']['is_range']:
+            instapy_args[param['name']] = random.randint(param['value']['min'], param['value']['max'])
+        else:
+            instapy_args[param['name']] = param['value']['single']
+    else:
+        instapy_args[param['name']] = param['value']
 
 # custom args
 instapy_args['log_handler'] = log_handler

--- a/services/instapy/bot.py
+++ b/services/instapy/bot.py
@@ -7,6 +7,7 @@ import json
 import platform
 import signal
 from os import getenv
+from decimal import Decimal
 from websocket import create_connection
 from instapy import InstaPy, set_workspace
 from instapy.util import smart_run
@@ -86,6 +87,17 @@ for job in res_jobs:
 # convert list to actual arrays / tuples
 actions = get('/actions')
 
+def get_number_of_digits_after_point(number):
+    return abs(Decimal(str(number)).as_tuple().exponent)
+
+def randomize_int(min_number, max_number):
+    return random.randint(min_number, max_number)
+
+def randomize_float(min_number, max_number):
+    N = max(get_number_of_digits_after_point(min_number), get_number_of_digits_after_point(max_number))
+    N = max(N, 2)
+    return round(random.uniform(min_number, max_number), N)
+
 for job in jobs:
     action = next(
         action for action in actions if action['functionName'] == job['functionName']
@@ -98,9 +110,10 @@ for job in jobs:
             if act_param['name'] == param['name']
         )
 
-        if act_param['type'] == 'int' and type(param['value']) is dict:
+        if (act_param['type'] == 'int' or act_param['type'] == 'float') and type(param['value']) is dict:
+            randomize_number = randomize_int if act_param['type'] == 'int' else randomize_float
             if param['value']['is_range']:
-                param['value'] = random.randint(param['value']['min'], param['value']['max'])
+                param['value'] = randomize_number(param['value']['min'], param['value']['max'])
             else:
                 param['value'] = param['value']['single']
             continue

--- a/src/sites/configuration/components/input_components.jsx
+++ b/src/sites/configuration/components/input_components.jsx
@@ -374,7 +374,7 @@ const inputComponents = {
 		props: { type: 'number', step: '1' }
 	},
 	float: {
-		element: InputBox, // TODO figure out how to change this
+		element: RangeBox,
 		props: { type: 'number', step: '0.01' }
 	},
 	bool: { element: BooleanBox, props: {} },

--- a/src/sites/configuration/components/input_components.jsx
+++ b/src/sites/configuration/components/input_components.jsx
@@ -213,16 +213,168 @@ export class BooleanBox extends Box {
 	}
 }
 
+class RangeBoxSmall extends Component {
+	render({is_range, classes, param, onValueChange, onMaximumChange, onMinimumChange, value, maximum, minimum, type=null, step=null}) {
+		if (is_range){
+			return(
+				<div className='row'>
+					<input
+						step={ step }
+						type={ type }
+						className={ classes }
+						placeholder={ param.placeholder }
+						value={ minimum }
+						onChange={ onMinimumChange }
+						style='width:auto'
+					/>
+					<h3
+					className='col-md-1'
+					> - </h3>
+					<input
+						step={ step }
+						type={ type }
+						className={ classes }
+						placeholder={ param.placeholder }
+						value={ maximum }
+						onChange={ onMaximumChange }
+						style='width:auto'
+					/>
+				</div>
+			);
+		}
+
+		return(
+			<input
+				step={ step }
+				type={ type }
+				className={ classes }
+				placeholder={ param.placeholder }
+				value={ value }
+				onChange={ onValueChange }
+				style='width:auto'
+			/>
+		);
+
+
+	}
+}
+
+
+export class RangeBox extends Box {
+	state = {
+		'is_range': false,
+		'single': null,
+		'min': null,
+		'max': null
+	}
+
+	componentWillMount() {
+		super.componentWillMount();
+		const { input } = this.state;
+
+		if (typeof input == 'number') {
+			this.setState({ is_range: false, single: input, min: null, max: null });
+			return
+		}
+
+		this.setState({ ...this.state, ...input })
+	}
+
+	is_not_defined = (input) => {
+		return input == '' || input == null || input == undefined
+	}
+
+	no_value = (params, value) => {
+		if(value) {
+			const index = params.indexOf(value);
+			if (index > -1) {
+				params.splice(index, 1);
+			}
+		}
+	}
+
+	validate = () => {
+		const { step, param, value, params } = this.props;
+		const {is_range, single, max, min} = this.state;
+		let parse_function = step == '1' ? parseInt : parseFloat;
+
+		if (is_range) {
+			if (this.is_not_defined(max) || this.is_not_defined(min)) {
+				if (param.optional){
+					this.setState({ input: null });
+				} else {
+					this.setState({ error: true })
+				}
+			} else if (parse_function(min)>=parse_function(max)) {
+				if (param.optional){
+					this.setState({ input: null });
+				} else {
+					this.setState({ error: true })
+				}
+			} else {
+				this.setState({ error: false, input: {is_range:is_range, max:parse_function(max), min:parse_function(min)} })
+			}
+		} else {
+			if ((this.is_not_defined(single) || single == param.defaultValue) && param.optional) {
+
+			} else {
+				this.setState({ error: false, input: { is_range:is_range, single:parse_function(single) } });
+			}
+		}
+
+		const value2 = this.setValue();
+		if (!value2) return true;
+
+		const { error } = this.state;
+		return !error;
+	}
+
+
+	render({ param, type=null, step = null }, { input, error, is_range, min, max, single }) {
+
+		const classes = classNames({
+			'form-control': true,
+			'is-invalid': error
+		});
+
+		return (
+			<div className='row'>
+				<input
+					type="checkbox"
+					checked={is_range}
+					onChange={ linkState(this, 'is_range')}
+					id="is_range" name="is_range"
+				/> {/* TODO having a cont id is a bad idea - find another way */}
+
+				<label for="is_range" className='col-md-2'>Pick from range</label>
+				<RangeBoxSmall
+					is_range={is_range}
+					param={param}
+					classes={classes}
+					type={type}
+					step={step}
+					value={single}
+					maximum={max}
+					minimum={min}
+					onValueChange={linkState(this, 'single')}
+					onMaximumChange={linkState(this, 'max')}
+					onMinimumChange={linkState(this, 'min')}
+					/>
+			</div>
+		);
+	}
+}
+
 const inputComponents = {
 	default: { element: InputBox, props: {} },
 	str: { element: InputBox, props: {} },
 	secret: { element: InputBox, props: { type: 'password' } },
 	int: {
-		element: InputBox,
+		element: RangeBox,
 		props: { type: 'number', step: '1' }
 	},
 	float: {
-		element: InputBox,
+		element: InputBox, // TODO figure out how to change this
 		props: { type: 'number', step: '0.01' }
 	},
 	bool: { element: BooleanBox, props: {} },


### PR DESCRIPTION
Fix https://github.com/breuerfelix/instapy-gui/issues/121

Idea:
Right now, every time we use the bot, we need to select a specific number for each action(posts to like, people to follow, precentage of private people to follow, etc). It can be an indication to instagram that we are using a bot and also forces the user to make multiple templates for things that can easily be randomized.

The way to solve it is randomize the number used each time - if the user desire it.

This mr contains the following:
1. Change in `auth.py` and `conf.py` to print errors in stderr (before that, the errors did not print properly)
2. Change to `bot.py` - handle the new range option, and also the old ones - for backward compatibility
3. `input_components.jsx` - handle the web side of the change, it is visible on every setting page or template that requires int - note that this is the first time I wrote p/react and used css code so please don't go easy on me.